### PR TITLE
fix: fix mode detection in webpack configuration

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,12 @@
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
-const nodeEnv = process.env.NODE_ENV || 'development';
-const isDev = nodeEnv !== 'production';
+const mode = process.argv.includes('--mode=production') ?
+  'production' : 'development';
+const isDev = mode !== 'production';
 
 const config = {
-  mode: nodeEnv,
+  mode: mode,
   entry: {
     'h5p-editor-csv-to-text': path.join(
       __dirname,


### PR DESCRIPTION
Since nodeENV is not used, the build mode will always be development and the resulting distribution files become unnecessarily large.

When merged in, will grab the mode information from webpack's argument variable that is set in package.json instead.