### PR TITLE
Fix output for missing cells

### DIFF
--- a/src/utils/csv.utils.test.ts
+++ b/src/utils/csv.utils.test.ts
@@ -125,7 +125,7 @@ ocean/sea;o___n;sjø;s_ø`;
       const csv = `ocean/sea;o___n;sjø;s_ø
 fire;f__e;ild✨;`;
 
-      const expected = ['ocean/sea:o___n,sjø:s_ø', 'fire:f__e,ild✨:'];
+      const expected = ['ocean/sea:o___n,sjø:s_ø', 'fire:f__e,ild✨'];
       const actual = parseCSV(csv, wordHintSeparator, languageSeparator);
 
       expect(actual).toStrictEqual(expected);
@@ -138,7 +138,7 @@ fire;f__e;ild✨;`;
       const csv = `ocean/sea,o___n,sjø,s_ø
 fire,f__e,ild✨,`;
 
-      const expected = ['ocean/sea:o___n,sjø:s_ø', 'fire:f__e,ild✨:'];
+      const expected = ['ocean/sea:o___n,sjø:s_ø', 'fire:f__e,ild✨'];
       const actual = parseCSV(csv, wordHintSeparator, languageSeparator);
 
       expect(actual).toStrictEqual(expected);
@@ -153,7 +153,7 @@ fire,f__e,ild✨,`;
 ;fire;f__e;ild✨;;;
 `;
 
-      const expected = ['ocean/sea:o___n,sjø:s_ø', 'fire:f__e,ild✨:'];
+      const expected = ['ocean/sea:o___n,sjø:s_ø', 'fire:f__e,ild✨'];
       const actual = parseCSV(csv, wordHintSeparator, languageSeparator);
 
       expect(actual).toStrictEqual(expected);

--- a/src/utils/csv.utils.ts
+++ b/src/utils/csv.utils.ts
@@ -83,8 +83,12 @@ export const parseCSV = (
           return `${sourceWord}${languageSeparator}${sourceHint}`;
         }
 
-        const source = `${sourceWord}${wordHintSeparator}${sourceHint}`;
-        const target = `${targetWord}${wordHintSeparator}${targetHint}`;
+        const source = sourceHint ?
+          `${sourceWord}${wordHintSeparator}${sourceHint}` :
+          sourceWord;
+        const target = targetHint ?
+          `${targetWord}${wordHintSeparator}${targetHint}` :
+          targetWord;
 
         return `${source}${languageSeparator}${target}`;
       }


### PR DESCRIPTION
When merged in, will not add empty hints to the output